### PR TITLE
Add missing CSS

### DIFF
--- a/templates/jinja/head.html
+++ b/templates/jinja/head.html
@@ -9,6 +9,11 @@
 
 <link href="{{ root_url }}/{{ url }}" rel="canonical">
 <link href="/assets/css/screen.css" media="screen, projection" rel="stylesheet" type="text/css">
+<link href="/assets/css/rst.css" media="screen, projection" rel="stylesheet" type="text/css">
+<link href="/assets/css/code.css" media="screen, projection" rel="stylesheet" type="text/css">
+{% if has_custom_css %}
+<link href="/assets/css/custom.css" media="screen, projection" rel="stylesheet" type="text/css">
+{% endif %}
 {% if rss_link %}<link href="{{ rss_link }}" rel="alternate" title="{{ title }}" type="application/atom+xml">{% endif %}
 {% if favicon %}<link href="{{ favicon }}" rel="icon">{% endif %}
 


### PR DESCRIPTION
Nikola requires rst.css and code.css to function properly.

Also, it would be nice to add favicons the Nikola way:

``` jinja
    {% if favicons %}
        {% for name, file, size in favicons %}
            <link rel="{{ name }}" href="{{ file }}" sizes="{{ size }}"/>
        {% endfor %}
    {% endif %}
```
